### PR TITLE
Improve Windows version number detection and display, WinTLS fix and new feature

### DIFF
--- a/Mile.Aria2.Library/FeatureConfig.h
+++ b/Mile.Aria2.Library/FeatureConfig.h
@@ -1,4 +1,4 @@
-﻿/* <!-- copyright */
+/* <!-- copyright */
 /*
  * aria2 - The high speed download utility
  *
@@ -70,6 +70,12 @@ std::string usedLibs();
 
 // Returns a summary string of the used compiler/platform.
 std::string usedCompilerAndPlatform();
+
+// Gets version info about Windows, supports Windows 10+
+#ifdef _WIN32
+BOOL GetNtVersionNumbers(DWORD& dwMajorVer, DWORD& dwMinorVer,
+                         DWORD& dwBuildNumber);
+#endif
 
 // Returns the system information about the OS this binary is running on.
 std::string getOperatingSystemInfo();

--- a/Mile.Aria2.Library/WinTLSContext.h
+++ b/Mile.Aria2.Library/WinTLSContext.h
@@ -43,6 +43,9 @@
 
 #include <windows.h>
 #include <security.h>
+
+#define SCHANNEL_USE_BLACKLISTS 1
+#include <subauth.h>
 #include <schnlsp.h>
 
 #include "TLSContext.h"
@@ -65,7 +68,7 @@ typedef std::unique_ptr<CredHandle, cred_deleter> CredPtr;
 
 class WinTLSContext : public TLSContext {
 public:
-  WinTLSContext(TLSSessionSide side, TLSVersion ver);
+  WinTLSContext(TLSSessionSide side, TLSVersion ver, DWORD dwMajorVersion, DWORD dwBuildNumber);
 
   virtual ~WinTLSContext();
 
@@ -90,7 +93,8 @@ public:
 
 private:
   TLSSessionSide side_;
-  SCHANNEL_CRED credentials_;
+  SCH_CREDENTIALS credentials_;
+  TLS_PARAMETERS tls_parameters_;
   HCERTSTORE store_;
   wintls::CredPtr cred_;
 };

--- a/Mile.Aria2.Library/WinTLSSession.cc
+++ b/Mile.Aria2.Library/WinTLSSession.cc
@@ -797,6 +797,9 @@ restart:
     case 0x303:
       version = TLS_PROTO_TLS12;
       break;
+    case 0x304:
+      version = TLS_PROTO_TLS13;
+      break;
     default:
       assert(0);
       abort();

--- a/Mile.Aria2.Library/WinTLSSession.cc
+++ b/Mile.Aria2.Library/WinTLSSession.cc
@@ -317,7 +317,7 @@ int WinTLSSession::sendTLSRecord()
 ssize_t WinTLSSession::writeData(const void* data, size_t len)
 {
   if (state_ == st_handshake_write || state_ == st_handshake_write_last ||
-      state_ == st_handshake_read) {
+      state_ == st_handshake_read || state_ == st_handshake_set) {
     // Renegotiating
     std::string hn, err;
     TLSVersion ver;
@@ -461,7 +461,7 @@ ssize_t WinTLSSession::readData(void* data, size_t len)
   }
 
   if (state_ == st_handshake_write || state_ == st_handshake_write_last ||
-      state_ == st_handshake_read) {
+      state_ == st_handshake_read || state_ == st_handshake_set) {
     // Renegotiating
     std::string hn, err;
     TLSVersion ver;
@@ -538,7 +538,7 @@ ssize_t WinTLSSession::readData(void* data, size_t len)
 
     if (status_ == SEC_I_RENEGOTIATE) {
       // Renegotiation basically means performing another handshake
-      state_ = st_initialized;
+      state_ = st_handshake_set;
       A2_LOG_INFO("WinTLS: Renegotiate");
       std::string hn, err;
       TLSVersion ver;
@@ -694,7 +694,10 @@ restart:
     if (!readBuf_.size()) {
       return TLS_ERR_WOULDBLOCK;
     }
+  }
+    // Fall through
 
+  case st_handshake_set: {
     // Need to copy the data, as Schannel is free to mess with it. But we
     // might later need unmodified data from the original read buffer.
     auto bufcopy = make_unique<char[]>(readBuf_.size());

--- a/Mile.Aria2.Library/WinTLSSession.h
+++ b/Mile.Aria2.Library/WinTLSSession.h
@@ -120,6 +120,7 @@ class WinTLSSession : public TLSSession {
     st_handshake_write,
     st_handshake_write_last,
     st_handshake_read,
+    st_handshake_set,
     st_handshake_done,
     st_connected,
     st_closing,

--- a/Mile.Aria2.Library/config.h
+++ b/Mile.Aria2.Library/config.h
@@ -508,6 +508,9 @@
 /* Define to 1 if you have the <winsock2.h> header file. */
 #define HAVE_WINSOCK2_H 1
 
+/* Define to 1 if you have Windows TLS */
+#define HAVE_WINTLS 1
+
 /* Define to 1 if `fork' works. */
 /* #undef HAVE_WORKING_FORK */
 


### PR DESCRIPTION
1. Use the undocumented function `RtlGetNtVersionNumbers` to get detailed Windows version info
2. Aria2 WinTLS does not correctly handle TLS renegotiation. Reference: [renegotiating-an-schannel-connection](https://learn.microsoft.com/en-us/windows/win32/secauthn/renegotiating-an-schannel-connection)
3. As Mile.Aria2 only supports Windows 10 2004 or later, migrate WinTLS to use new schannel API added in Windows 10 1809
4. With the new schannel API, TLSv1.3 support with WinTLS is added