### PR TITLE
Mile.Aria2.Library: BufferedFile: updated onClose() function

### DIFF
--- a/Mile.Aria2.Library/BufferedFile.cc
+++ b/Mile.Aria2.Library/BufferedFile.cc
@@ -55,6 +55,7 @@ BufferedFile::BufferedFile(const char* filename, const char* mode)
               ),
       supportsColor_(fp_ ? isatty(fileno(fp_)) : false)
 {
+    Mode = mode;
 }
 
 BufferedFile::BufferedFile(FILE* fp)
@@ -80,12 +81,14 @@ int BufferedFile::onClose()
 {
   int rv = 0;
   if (fp_) {
+    if (strcmp(Mode, "rb") != 0) {
     fflush(fp_);
 #ifndef __MINGW32__
     fsync(fileno(fp_));
 #else  // __MINGW32__
-    _commit(fileno(fp_));
+        _commit(fileno(fp_));
 #endif // __MINGW32__
+    }
     if (fp_ != stdin && fp_ != stderr) {
       rv = fclose(fp_);
     }

--- a/Mile.Aria2.Library/BufferedFile.h
+++ b/Mile.Aria2.Library/BufferedFile.h
@@ -44,6 +44,7 @@ namespace aria2 {
 // IOFILE implementation using standard I/O functions.
 class BufferedFile : public IOFile {
 public:
+  const char* Mode;
   BufferedFile(const char* filename, const char* mode);
   BufferedFile(FILE* fp);
   virtual ~BufferedFile();


### PR DESCRIPTION
Reason:  File open in "Read" mode need not flush to disk before closing. here when BufferedFile destructor called, it flush file even file is opened in read mode which give error if _commit function exectuted (in windows)

Issue #2 fixed


